### PR TITLE
Convert and format

### DIFF
--- a/packages/vscode-extension/src/commands/convert.ts
+++ b/packages/vscode-extension/src/commands/convert.ts
@@ -16,6 +16,7 @@ import { formatPTX } from "../formatter";
 import { FlexTeXtConvert } from "frankenmarkup";
 import { get } from "http";
 import { Environment, Macro } from "@unified-latex/unified-latex-types";
+import { lspFormatText } from "../lsp-client/main";
 
 export function cmdConvertToPretext() {
   console.log("Converting to PreTeXt");
@@ -147,9 +148,9 @@ export function cmdMarkdownToPretext() {
   }
 }
 
-export async function cmdConvertFlextextToPretext() {
+export async function cmdConvertMixedtextToPretext() {
   pretextOutputChannel.appendLine(
-    "Flextext to PreTeXt conversion is still very experiemental.  Use with care."
+    "Mixed text to PreTeXt conversion is still very experiemental.  Use with care."
   );
   const editor = window.activeTextEditor;
   console.log("editor is", editor);
@@ -170,8 +171,8 @@ export async function cmdConvertFlextextToPretext() {
     const initialText = editor.document.getText(selectionRange);
     console.log("initialText is", initialText);
 
-    var newText = FlexTeXtConvert(initialText);
-
+    const newText = FlexTeXtConvert(initialText);
+    const formattedNewText = lspFormatText(newText);
     editor.edit((editbuilder) => {
       editbuilder.replace(selectionRange, newText);
     });

--- a/packages/vscode-extension/src/commands/convert.ts
+++ b/packages/vscode-extension/src/commands/convert.ts
@@ -153,7 +153,6 @@ export async function cmdConvertMixedtextToPretext() {
     "Mixed text to PreTeXt conversion is still very experiemental.  Use with care."
   );
   const editor = window.activeTextEditor;
-  console.log("editor is", editor);
   if (editor) {
     const selection = editor.selection;
     let selectionRange: Range;
@@ -167,22 +166,12 @@ export async function cmdConvertMixedtextToPretext() {
     } else {
       selectionRange = new Range(selection.start, selection.end);
     }
-    console.log("selectionRange is", selectionRange);
     const initialText = editor.document.getText(selectionRange);
-    console.log("initialText is", initialText);
-
     const newText = FlexTeXtConvert(initialText);
-    const formattedNewText = lspFormatText(newText);
+    const formattedNewText = await lspFormatText(newText);
     editor.edit((editbuilder) => {
-      editbuilder.replace(selectionRange, newText);
+      editbuilder.replace(selectionRange, formattedNewText);
     });
-    // Call default formatter to format just the replaced selection.
-    if (fullDocument) {
-      commands.executeCommand("editor.action.formatDocument");
-    } else {
-      commands.executeCommand("editor.action.formatSelection");
-    }
-    pretextOutputChannel.appendLine("FlexTeXt converted to PreTeXt.");
-    console.log("Formatted text");
+    pretextOutputChannel.appendLine("Mixed text converted to PreTeXt.");
   }
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -29,7 +29,7 @@ import { cmdDeploy } from "./commands/deploy";
 import { cmdUpdate } from "./commands/update";
 //import { ptxExperiment } from "./commands/experiment";
 import {
-  cmdConvertFlextextToPretext,
+  cmdConvertMixedtextToPretext,
   cmdConvertToPretext,
   cmdLatexToPretext,
   cmdMarkdownToPretext,
@@ -45,12 +45,12 @@ import { cmdSelectCommand } from "./commands/select";
 import {
   activate as lspActivate,
   deactivate as lspDeactivate,
+  lspFormat,
+  lspFormatText,
 } from "./lsp-client/main";
 import { projects } from "./project";
 import { cmdInstallSage } from "./commands/installSage";
 import { PretextVisualEditorProvider } from "./visualEditor";
-import { cli } from "./cli";
-import { client } from "./lsp-client/main";
 
 // this method is called when your extension is activated
 export async function activate(context: ExtensionContext) {
@@ -159,16 +159,17 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("pretext-tools.new", cmdNew),
     commands.registerCommand("pretext-tools.deploy", cmdDeploy),
     commands.registerCommand("pretext-tools.updatePTX", cmdUpdate),
-    //commands.registerCommand("pretext-tools.formatPretextDocument", (doc) => {
-    //  if (doc) {
-    //    return formatDocument(doc);
-    //  } else {
-    //    console.log("No document provided to format");
-    //  }
-    //}),
+    commands.registerCommand("pretext-tools.formatPretextDocument", () => {
+      const activeEditor = window.activeTextEditor;
+      if (activeEditor) {
+        return lspFormat(activeEditor);
+      } else {
+        console.log("No document provided to format");
+      }
+    }),
     commands.registerCommand(
       "pretext-tools.ftToPtx",
-      cmdConvertFlextextToPretext
+      cmdConvertMixedtextToPretext
     ),
     commands.registerCommand("pretext-tools.latexToPretext", cmdLatexToPretext),
     commands.registerCommand(

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -45,7 +45,7 @@ import { cmdSelectCommand } from "./commands/select";
 import {
   activate as lspActivate,
   deactivate as lspDeactivate,
-  lspFormat,
+  lspFormatDocument,
   lspFormatText,
 } from "./lsp-client/main";
 import { projects } from "./project";
@@ -100,23 +100,6 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(ptxSBItem);
   utils.updateStatusBarItem(ptxSBItem);
 
-  ///////////////// Formatter //////////////////////
-
-  // try {
-  //   let formatter = languages.registerDocumentFormattingEditProvider(
-  //     "pretext",
-  //     {
-  //       provideDocumentFormattingEdits(document: TextDocument): TextEdit[] {
-  //         return formatPretextDocument(document);
-  //       },
-  //     }
-  //   );
-
-  //   context.subscriptions.push(formatter);
-  // } catch {
-  //   console.log("Error setting up formatter");
-  // }
-
   // Visual editor
   context.subscriptions.push(PretextVisualEditorProvider.register(context));
 
@@ -127,18 +110,8 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand("pretext-tools.experiment", () => {
       console.log("Running PreTeXt experiment command");
-      // Example: Triggering a custom command from the client
-      // This is cool.  It will allow us to complete custom things throught the LSP.
-      // This is formatting
-      const activeEditor = window.activeTextEditor;
-      if (activeEditor) {
-        client.sendRequest("workspace/executeCommand", {
-          command: "formatDocument",
-          arguments: [{ uri: activeEditor.document.uri.toString() }],
-        });
-      } else {
-        console.log("No active editor found to format document.");
-      }
+      // Notify that no experiment command is currently available
+      pretextOutputChannel.appendLine("No experiment command is implemented.");
       //utils.experiment(context);
     }),
     commands.registerCommand(
@@ -162,7 +135,7 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("pretext-tools.formatPretextDocument", () => {
       const activeEditor = window.activeTextEditor;
       if (activeEditor) {
-        return lspFormat(activeEditor);
+        return lspFormatDocument(activeEditor);
       } else {
         console.log("No document provided to format");
       }

--- a/packages/vscode-extension/src/lsp-client/main.ts
+++ b/packages/vscode-extension/src/lsp-client/main.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from "path";
-import { ExtensionContext, workspace } from "vscode";
+import { ExtensionContext, TextEditor, window, workspace } from "vscode";
 
 import {
   LanguageClient,
@@ -15,7 +15,28 @@ import {
 
 import { pretextOutputChannel } from "../ui";
 
-export let client: LanguageClient;
+let client: LanguageClient;
+
+export function lspFormat(editor: TextEditor) {
+  if (editor) {
+    client.sendRequest('workspace/executeCommand', {
+      command: 'formatDocument',
+      arguments: [{ uri: editor.document.uri.toString() }],
+    });
+  } else {
+    console.log("No active editor found to format document.");
+  }
+}
+
+export function lspFormatText(text: string) {
+  client.sendRequest('workspace/executeCommand', {
+    command: 'formatText',
+    arguments: [{ text: text }]
+  })
+  //Need to get the text back from the LSP.
+  console.log("Done!")
+}
+
 
 export function activate(context: ExtensionContext) {
   // The server is implemented in node

--- a/packages/vscode-extension/src/lsp-client/main.ts
+++ b/packages/vscode-extension/src/lsp-client/main.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from "path";
-import { ExtensionContext, TextEditor, window, workspace } from "vscode";
+import { ExtensionContext, TextEditor, workspace } from "vscode";
 
 import {
   LanguageClient,
@@ -17,10 +17,10 @@ import { pretextOutputChannel } from "../ui";
 
 let client: LanguageClient;
 
-export function lspFormat(editor: TextEditor) {
+export function lspFormatDocument(editor: TextEditor) {
   if (editor) {
-    client.sendRequest('workspace/executeCommand', {
-      command: 'formatDocument',
+    client.sendRequest("workspace/executeCommand", {
+      command: "formatDocument",
       arguments: [{ uri: editor.document.uri.toString() }],
     });
   } else {
@@ -28,15 +28,20 @@ export function lspFormat(editor: TextEditor) {
   }
 }
 
-export function lspFormatText(text: string) {
-  client.sendRequest('workspace/executeCommand', {
-    command: 'formatText',
-    arguments: [{ text: text }]
-  })
-  //Need to get the text back from the LSP.
-  console.log("Done!")
+export async function lspFormatText(text: string): Promise<string> {
+  const result = await client.sendRequest("workspace/executeCommand", {
+    command: "formatText",
+    arguments: [{ text: text }],
+  });
+  console.log("Formatted text in thenable:", result);
+  if (typeof result === "string") {
+    return result;
+  } else {
+    throw new Error(
+      "Expected string result from formatText, got: " + typeof result
+    );
+  }
 }
-
 
 export function activate(context: ExtensionContext) {
   // The server is implemented in node

--- a/packages/vscode-extension/src/lsp-server/formatter-classic.ts
+++ b/packages/vscode-extension/src/lsp-server/formatter-classic.ts
@@ -461,16 +461,14 @@ export async function formatRange(
   return null;
 }
 
-
-export async function formatText(
-  params: {text: string}
-): Promise<string|null> {
-
+export async function formatText(params: {
+  text: string;
+}): Promise<string | null> {
   const origText = params.text;
   console.log("formatting with PreTeXt's classic formatter.");
 
   try {
-    console.log(`formatting: ${origText}`)
+    console.log(`formatting: ${origText}`);
     let formatted = formatPTX(origText);
     console.log("formatted", formatted);
     return formatted;

--- a/packages/vscode-extension/src/lsp-server/formatter-classic.ts
+++ b/packages/vscode-extension/src/lsp-server/formatter-classic.ts
@@ -460,3 +460,22 @@ export async function formatRange(
   }
   return null;
 }
+
+
+export async function formatText(
+  params: {text: string}
+): Promise<string|null> {
+
+  const origText = params.text;
+  console.log("formatting with PreTeXt's classic formatter.");
+
+  try {
+    console.log(`formatting: ${origText}`)
+    let formatted = formatPTX(origText);
+    console.log("formatted", formatted);
+    return formatted;
+  } catch (e) {
+    console.log("Could not format range", e);
+  }
+  return null;
+}

--- a/packages/vscode-extension/src/lsp-server/main.ts
+++ b/packages/vscode-extension/src/lsp-server/main.ts
@@ -281,24 +281,23 @@ connection.onCodeAction((params) => {
   return [{ title: "My Custom Action" }];
 });
 connection.onExecuteCommand(async (params) => {
-  console.log("asked to execute", params.command);
+  // Handle commands sent from the client
   if (params.command === "formatText") {
-    console.log("Formatting text", params.arguments);
-    if (params.arguments && params.arguments[0] && typeof params.arguments[0].text === "string") {
-      const newText = await formatText({text: params.arguments[0].text});
-      console.log("New text:", newText);
-      // Need to send back the nextText.
+    if (
+      params.arguments &&
+      params.arguments[0] &&
+      typeof params.arguments[0].text === "string"
+    ) {
+      const newText = await formatText({ text: params.arguments[0].text });
+      return newText;
     }
-  }
-  if (params.command === "formatDocument") {
-    console.log("formatting document", params.arguments);
+  } else if (params.command === "formatDocument") {
     if (
       params.arguments &&
       params.arguments[0] &&
       typeof params.arguments[0].uri === "string"
     ) {
       const uri = params.arguments[0].uri;
-      console.log("uri is", uri);
       const edits = await formatDocument({
         textDocument: { uri },
         options: {
@@ -306,7 +305,6 @@ connection.onExecuteCommand(async (params) => {
           insertSpaces: globalSettings.editor.insertSpaces,
         },
       });
-      console.log("edits for", uri, edits);
       connection.sendRequest("workspace/applyEdit", {
         edit: { changes: { [uri]: edits } },
       });

--- a/packages/vscode-extension/src/lsp-server/main.ts
+++ b/packages/vscode-extension/src/lsp-server/main.ts
@@ -29,7 +29,7 @@ import {
   getCompletionDetails,
 } from "./completions/get-completions";
 //import { formatDocument, formatRange } from "./formatter";
-import { formatDocument, formatRange } from "./formatter-classic";
+import { formatDocument, formatRange, formatText } from "./formatter-classic";
 import { getReferences, updateReferences } from "./completions/utils";
 import { getAst, initializeSchema, Schema } from "./schema";
 import path from "path";
@@ -282,6 +282,14 @@ connection.onCodeAction((params) => {
 });
 connection.onExecuteCommand(async (params) => {
   console.log("asked to execute", params.command);
+  if (params.command === "formatText") {
+    console.log("Formatting text", params.arguments);
+    if (params.arguments && params.arguments[0] && typeof params.arguments[0].text === "string") {
+      const newText = await formatText({text: params.arguments[0].text});
+      console.log("New text:", newText);
+      // Need to send back the nextText.
+    }
+  }
   if (params.command === "formatDocument") {
     console.log("formatting document", params.arguments);
     if (


### PR DESCRIPTION
Previously when converting from mixed text, there would be a separate call to the formatter for the whole document.  This implements a way for the extension to request specific text is put through the LSP formatter and returned, and this process is used as part of the conversion process.